### PR TITLE
These changes add support for Touch ID on macOS builds. The change is…

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -52,7 +52,12 @@ include_directories(${CURL_INCLUDE_DIR})
 set(PROJECT_NAME lpass)
 
 file(GLOB PROJECT_HEADERS *.h version.h)
-file(GLOB PROJECT_SOURCES *.c)
+# only compile localauthentication.m on Apple builds
+if((APPLE))
+    file(GLOB PROJECT_SOURCES *.c *.m)
+else()
+    file(GLOB PROJECT_SOURCES *.c)
+endif()
 
 set(PROJECT_DEFINITIONS "_GNU_SOURCE")
 
@@ -76,6 +81,10 @@ target_link_libraries(${PROJECT_NAME} ${LIBXML2_LIBRARIES} ${OPENSSL_LIBRARIES} 
 if (CMAKE_SYSTEM_NAME MATCHES "OpenBSD")
   target_link_libraries(${PROJECT_NAME} "-lkvm")
 endif (CMAKE_SYSTEM_NAME MATCHES "OpenBSD")
+# Link CoreFoundation and LocalAuthentication frameworks on Apple builds
+if((APPLE))
+    target_link_libraries(${PROJECT_NAME} "-framework CoreFoundation -framework LocalAuthentication")
+endif()
 
 add_custom_command(OUTPUT lpass.1 DEPENDS ${CMAKE_SOURCE_DIR}/lpass.1.txt
         COMMAND a2x -D ./ --no-xmllint -f manpage ${CMAKE_SOURCE_DIR}/lpass.1.txt)

--- a/LASTPASS-VERSION-GEN
+++ b/LASTPASS-VERSION-GEN
@@ -21,7 +21,7 @@ elif test -d ${GIT_DIR:-.git} -o -f .git &&
 	v[0-9]*)
 		git update-index -q --refresh
 		test -z "$(git diff-index --name-only HEAD --)" ||
-		VN="$VN-dirty" ;;
+		VN="$VN-dirty-macos-touchid" ;;
 	esac
 then
 	VN=$(echo "$VN" | sed -e 's/-/./g');

--- a/cmd.c
+++ b/cmd.c
@@ -36,12 +36,17 @@
 #include "cmd.h"
 #include "agent.h"
 #include "blob.h"
+#include "endpoints.h"
 #include "session.h"
 #include "util.h"
 #include "process.h"
 #include <strings.h>
 #include <string.h>
 #include <regex.h>
+
+#if defined(__APPLE__) 
+#include "localauthentication.h"
+#endif
 
 enum blobsync parse_sync_string(const char *syncstr)
 {
@@ -91,6 +96,14 @@ enum note_type parse_note_type_string(const char *extra)
 
 void init_all(enum blobsync sync, unsigned char key[KDF_HASH_LEN], struct session **session, struct blob **blob)
 {
+
+#if defined(__APPLE__) 
+        int _localauthresult = localauthentication();
+        if(_localauthresult != 0) {
+                die("Failed due to macOS Touch ID.");
+        }
+#endif
+        
 	if (!agent_get_decryption_key(key))
 		die("Could not find decryption key. Perhaps you need to login with `%s login`.", ARGV[0]);
 

--- a/cmd.h
+++ b/cmd.h
@@ -81,16 +81,16 @@ int cmd_passwd(int argc, char **argv);
 #define cmd_passwd_usage "passwd"
 
 int cmd_show(int argc, char **argv);
-#define cmd_show_usage "show [--sync=auto|now|no] [--clip, -c] [--quiet, -q] [--expand-multi, -x] [--json, -j] [--all|--username|--password|--url|--notes|--field=FIELD|--id|--name|--attach=ATTACHID] [--basic-regexp, -G|--fixed-strings, -F] " color_usage " {UNIQUENAME|UNIQUEID}"
+#define cmd_show_usage "show [--sync=auto|now|no]\n\t[--clip, -c]\n\t[--quiet, -q]\n\t[--expand-multi, -x]\n\t[--json, -j]\n\t[--all|--username|--password|--url|--notes|--field=FIELD|--id|--name|--attach=ATTACHID]\n\t[--basic-regexp, -G|--fixed-strings, -F]\n\t" color_usage " {UNIQUENAME|UNIQUEID}"
 
 int cmd_ls(int argc, char **argv);
 #define cmd_ls_usage "ls [--sync=auto|now|no] [--long, -l] [-m] [-u] " color_usage " [GROUP]"
 
 int cmd_add(int argc, char **argv);
-#define cmd_add_usage "add [--sync=auto|now|no] [--non-interactive] " color_usage " {--username|--password|--url|--notes|--field=FIELD|--note-type=NOTETYPE} NAME"
+#define cmd_add_usage "add [--sync=auto|now|no]\n\t[--non-interactive]\n\t" color_usage " {--username|--password|--url|--notes|--field=FIELD|--note-type=NOTETYPE} NAME"
 
 int cmd_edit(int argc, char **argv);
-#define cmd_edit_usage "edit [--sync=auto|now|no] [--non-interactive] " color_usage " {--name|--username|--password|--url|--notes|--field=FIELD} {NAME|UNIQUEID}"
+#define cmd_edit_usage "edit [--sync=auto|now|no]\n\t[--non-interactive]\n\t" color_usage " {--name|--username|--password|--url|--notes|--field=FIELD} {NAME|UNIQUEID}"
 
 int cmd_generate(int argc, char **argv);
 #define cmd_generate_usage "generate [--sync=auto|now|no] [--clip, -c] [--username=USERNAME] [--url=URL] [--no-symbols] {NAME|UNIQUEID} LENGTH"

--- a/localauthentication.h
+++ b/localauthentication.h
@@ -1,0 +1,6 @@
+#ifndef LOCALAUTHENTICATION_H
+#define LOCALAUTHENTICATION_H
+#if defined(__APPLE__) 
+int localauthentication();
+#endif
+#endif

--- a/localauthentication.m
+++ b/localauthentication.m
@@ -1,0 +1,71 @@
+//
+//  localauthentication.m
+//  Todd Manning 
+//
+
+#import <Foundation/Foundation.h>
+#import <LocalAuthentication/LocalAuthentication.h>
+#import <stdio.h>
+
+typedef enum {
+    kTouchIDResultAllowed,
+    kTouchIDResultNone,
+    kTouchIDResultFailed
+} TouchIDResult;
+
+
+int localauthentication() {
+    @autoreleasepool {
+        LAContext *myContext = [[LAContext alloc] init];
+        NSString *myLocalizedReasonString = @"access LastPass password";
+
+        __block NSError *authError = nil;
+        __block TouchIDResult result = kTouchIDResultNone;
+        
+        
+        if ([myContext canEvaluatePolicy:LAPolicyDeviceOwnerAuthenticationWithBiometrics error:&authError]) {
+            // biometryType is only set after calling canEvaluatePolicy
+            if (@available(macOS 10.13.2, *)) {
+            
+                // test for the types of biometry available on the current device
+                // currently not using this, but the idea would be you could customize
+                // based on how the user could locally authenticate
+                switch(myContext.biometryType) {
+                    case LABiometryTypeNone:
+                        break;
+                    case LABiometryTypeTouchID:
+                        break;
+                    // currently only iOS supports FaceID
+                    case LABiometryTypeFaceID:
+                        break;
+                }
+
+            } 
+
+            [myContext evaluatePolicy:LAPolicyDeviceOwnerAuthenticationWithBiometrics
+                      localizedReason:myLocalizedReasonString
+                                reply:^(BOOL success, NSError *error) {
+                                    result = success ? kTouchIDResultAllowed : kTouchIDResultFailed;
+                                    authError = error;
+                                    CFRunLoopWakeUp(CFRunLoopGetCurrent());
+                                }];
+            
+            while (result == kTouchIDResultNone) {
+                CFRunLoopRunInMode(kCFRunLoopDefaultMode, 0, true);
+            }
+            
+            if (result == kTouchIDResultAllowed) {
+                // printf("Biometric authentication succeeded\n");
+            } else {
+                // printf("Biometric authentication failed, errorcode==%ld userinfo=%s\n", (long)authError.code, [authError.localizedDescription UTF8String]);
+            }
+            
+        } else {
+            // Could not evaluate policy
+            // printf("Could not perform biometric authentication...errorcode==%ld userinfo=%s\n", (long)authError.code, [authError.localizedDescription UTF8String]);
+        }
+        
+        return (int)authError.code;
+
+    }
+}


### PR DESCRIPTION
… very small, and because it happends inside init_all(), it should gate all accesses to the vault. This change adds localauthentication.m to integrate the LocalAuthentication code to perform Touch ID. CMakeLists.txt was changed to add the new source to the build and link in the proper macOS frameworks. Changes were made to the --help output for readability